### PR TITLE
NXP-12189 fix LibreOffice detection

### DIFF
--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/OfficeUtils.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/OfficeUtils.java
@@ -105,7 +105,7 @@ public class OfficeUtils {
             File file = new File(officeHome, "MacOS/soffice.bin");
             if (!file.isFile()) {
                 // LibreOffice 4.1.0
-                new File(officeHome, "MacOS/soffice");
+                file = new File(officeHome, "MacOS/soffice");
             }
             return file;
         } else {


### PR DESCRIPTION
Fix problem Jodconverter doesn't work on Mac OSX + LibreOffice 4.1
